### PR TITLE
TST: Adding testing for lapack gttrf and gttrs

### DIFF
--- a/scipy/linalg/flapack_gen_tri.pyf.src
+++ b/scipy/linalg/flapack_gen_tri.pyf.src
@@ -16,7 +16,7 @@ end subroutine <prefix>gtsv
 
 
 subroutine <prefix>gttrf(n, dl, d, du, du2, ipiv, info)
-    ! dl, d, du, du2, ipiv, info  = gttrf(dl, d, du)
+    ! dl, d, du, du2, ipiv, info  = gttrf(dl, d, du, [overwrite_dl=0, overwrite_d=0, overwrite_du=0])
     ! ?GTTRF computes an LU factorization of a tridiagonal matrix A
     ! using elimination with partial pivoting and row interchanges.
     !
@@ -30,14 +30,15 @@ subroutine <prefix>gttrf(n, dl, d, du, du2, ipiv, info)
     callprotoargument int*, <ctype>*, <ctype>*, <ctype>*, <ctype>*, int*, int*
 
     integer intent(hide),   depend(d), check(len(d) > 2) :: n = len(d)
-    <ftype> intent(in,out), depend(n), dimension(n-1)    :: dl
-    <ftype> intent(in,out),            dimension(n)      :: d
-    <ftype> intent(in,out), depend(n), dimension(n-1)    :: du
+    <ftype> intent(in,out,copy), depend(n), dimension(n-1) :: dl
+    <ftype> intent(in,out,copy),            dimension(n)   :: d
+    <ftype> intent(in,out,copy), depend(n), dimension(n-1) :: du
     <ftype> intent(out),    depend(n), dimension(n-2)    :: du2
     integer intent(out),    depend(n), dimension(n)      :: ipiv
     integer intent(out)                                  :: info
 
 end subroutine <prefix>gttrf
+
 
 subroutine <prefix>gttrs(trans, n, nrhs, dl, d, du, du2, ipiv, b, ldb, info)
     ! x, info  = gttrs(dl, d, du, du2, ipiv, b, trans="N")

--- a/scipy/linalg/flapack_gen_tri.pyf.src
+++ b/scipy/linalg/flapack_gen_tri.pyf.src
@@ -41,7 +41,7 @@ end subroutine <prefix>gttrf
 
 
 subroutine <prefix>gttrs(trans, n, nrhs, dl, d, du, du2, ipiv, b, ldb, info)
-    ! x, info  = gttrs(dl, d, du, du2, ipiv, b, trans="N")
+    ! x, info  = gttrs(dl, d, du, du2, ipiv, b, trans="N", overwrite_b=0)
     !
     ! ?GTTRS solves one of the systems of equations:
     ! A*X = B  or  A**T*X = B,
@@ -60,7 +60,7 @@ subroutine <prefix>gttrs(trans, n, nrhs, dl, d, du, du2, ipiv, b, ldb, info)
     <ftype>    intent(in), depend(n), dimension(n - 1) :: du
     <ftype>    intent(in), depend(n), dimension(n - 2) :: du2
     integer    intent(in), depend(n), dimension(n)     :: ipiv
-    <ftype>    intent(in, out),       dimension(ldb, nrhs) :: b
+    <ftype>    intent(in, out, copy), dimension(ldb, nrhs) :: b
     integer    intent(out) :: info
 
 end subroutine gttrs

--- a/scipy/linalg/flapack_gen_tri.pyf.src
+++ b/scipy/linalg/flapack_gen_tri.pyf.src
@@ -13,3 +13,28 @@ subroutine <prefix>gtsv(n, nrhs, dl, d, du, b, info)
     integer intent(out) :: info
 
 end subroutine <prefix>gtsv
+
+
+subroutine <prefix>gttrf(n, dl, d, du, du2, ipiv, info)
+    ! dl, d, du, du2, ipiv, info  = gttrf(dl, d, du)
+    ! ?GTTRF computes an LU factorization of a tridiagonal matrix A
+    ! using elimination with partial pivoting and row interchanges.
+    !
+    ! The factorization has the form
+    !    A = L * U
+    !
+    ! where L is a product of permutation and unit lower bidiagonal
+    ! matrices and U is upper triangular with nonzeros in only the main
+    ! diagonal and first two superdiagonals.
+    callstatement (*f2py_func)(&n, dl, d, du, du2, ipiv, &info)
+    callprotoargument int*, <ctype>*, <ctype>*, <ctype>*, <ctype>*, int*, int*
+
+    integer intent(hide),   depend(d), check(len(d) > 2) :: n = len(d)
+    <ftype> intent(in,out), depend(n), dimension(n-1)    :: dl
+    <ftype> intent(in,out),            dimension(n)      :: d
+    <ftype> intent(in,out), depend(n), dimension(n-1)    :: du
+    <ftype> intent(out),    depend(n), dimension(n-2)    :: du2
+    integer intent(out),    depend(n), dimension(n)      :: ipiv
+    integer intent(out)                                  :: info
+
+end subroutine <prefix>gttrf

--- a/scipy/linalg/flapack_gen_tri.pyf.src
+++ b/scipy/linalg/flapack_gen_tri.pyf.src
@@ -38,3 +38,28 @@ subroutine <prefix>gttrf(n, dl, d, du, du2, ipiv, info)
     integer intent(out)                                  :: info
 
 end subroutine <prefix>gttrf
+
+subroutine <prefix>gttrs(trans, n, nrhs, dl, d, du, du2, ipiv, b, ldb, info)
+    ! x, info  = gttrs(dl, d, du, du2, ipiv, b, trans="N")
+    !
+    ! ?GTTRS solves one of the systems of equations:
+    ! A*X = B  or  A**T*X = B,
+    ! with a tridiagonal matrix A using the LU factorization computed
+    ! by ?GTTRF.
+    callstatement (*f2py_func)(trans, &n, &nrhs, dl, d, du, du2, ipiv, b, &ldb, &info)
+    callprotoargument char*, int*, int*, <ctype>*, <ctype>*, <ctype>*, <ctype>*, int*, <ctype>*, int*, int*
+    threadsafe
+
+    character  optional, intent(in), check(*trans=='N'||*trans=='T'||*trans=='C') :: trans = "N"
+    integer    intent(in, hide), depend(d), check(len(d) > 2) :: n = len(d)
+    integer    intent(in, hide), depend(b), check(nrhs > 0)  :: nrhs = shape(b, 1)
+    integer    intent(in, hide), depend(b), check(ldb >= MAX(1, n)):: ldb = shape(b, 0)
+    <ftype>    intent(in), depend(n), dimension(n - 1) :: dl
+    <ftype>    intent(in),            dimension(n)     :: d
+    <ftype>    intent(in), depend(n), dimension(n - 1) :: du
+    <ftype>    intent(in), depend(n), dimension(n - 2) :: du2
+    integer    intent(in), depend(n), dimension(n)     :: ipiv
+    <ftype>    intent(in, out),       dimension(ldb, nrhs) :: b
+    integer    intent(out) :: info
+
+end subroutine gttrs

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -650,6 +650,11 @@ All functions
    cgttrf
    zgttrf
 
+   sgttrs
+   dgttrs
+   cgttrs
+   zgttrs
+
    stpqrt
    dtpqrt
    ctpqrt

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -645,6 +645,11 @@ All functions
    cgemqrt
    zgemqrt
 
+   sgttrf
+   dgttrf
+   cgttrf
+   zgttrf
+
    stpqrt
    dtpqrt
    ctpqrt

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1729,3 +1729,31 @@ def test_gttrf_gttrs():
         __dl, __d, __du, _du2, _ipiv, _info = gttrf(dl, d, du)
         np.testing.assert_(_info != 0,
                            "?gttrf: singular matrix ret info == 0")
+
+    du = np.array([2.1, -1.0, 1.9, 8.0])
+    d = np.array([3.0, 2.3, -5.0, -.9, 7.1])
+    dl = np.array([3.4, 3.6, 7.0, -6.0])
+
+    gttrf, gttrs = get_lapack_funcs(('gttrf', "gttrs"), (du[0], du[0]))
+
+    _dl, _d, _du, du2, ipiv, info = gttrf(dl, d, du)
+    assert_allclose(du2, np.array([-1.0000, 1.90000, 8.0000]))
+    assert_allclose(_du, np.array([2.3, -5, -.9, 7.1]))
+    assert_allclose(_d, np.array([3.4, 3.6, 7, -6, -1.0154]), rtol=.001)
+    assert_allclose(ipiv, np.array([2, 3, 4, 5, 5]))
+
+    b = np.array([[2.7, 6.6],
+                  [-0.5, 10.8],
+                  [2.6, -3.2],
+                  [0.6, -11.2],
+                  [2.7, 19.1]
+                  ])
+
+    x_gttrs, info = gttrs(_dl, _d, _du, du2, ipiv, b)
+    x = np.array([[-4.0000, 5.0000],
+                  [7.0000, -4.0000],
+                  [3.0000, -3.0000],
+                  [-4.0000, -2.0000],
+                  [-3.0000, 1.0000]
+                  ])
+    assert_allclose(x_gttrs, x)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1686,6 +1686,7 @@ def test_gttrf_gttrs(dtype):
 
     for i, m in enumerate(_dl):
         # L is given in a factored form.
+        # See http://www.hpcavf.uclan.ac.uk/softwaredoc/sgi_scsl_html/sgi_html/ch03.html
         piv = ipiv[i] - 1
         # right multiply by permutation matrix
         L[:, [i, piv]] = L[:, [piv, i]]

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1645,3 +1645,50 @@ def test_getc2_gesc2():
         else:
             assert_array_almost_equal(desired_cplx.astype(dtype),
                                       x/scale, decimal=4)
+
+
+def test_gttrf_gttrs():
+    np.random.seed(42)
+    n = 10
+    for index, dtype in enumerate(DTYPES):
+        atol = 10**-(np.finfo(dtype).precision-1)
+        if index < 2:
+            du = np.random.rand(n-1)
+            d = np.random.rand(n)
+            dl = np.random.rand(n-1)
+        else:
+            du = np.random.rand(n-1) * 1j
+            d = np.random.rand(n) * 1j
+            dl = np.random.rand(n-1) * 1j
+
+        diag_cpy = np.array([dl.copy(), d.copy(), du.copy()])
+
+        A = np.diag(d) + np.diag(dl, -1) + np.diag(du, 1)
+        x = np.random.rand(n)
+        b = A @ x
+
+        dgttrf = get_lapack_funcs('gttrf', dtype=dtype)
+        dgttrs = get_lapack_funcs('gttrs', dtype=dtype)
+
+        _dl, _d, _du, du2, ipiv, info = dgttrf(dl, d, du)
+
+        np.testing.assert_allclose(dl, diag_cpy[0], atol=atol)
+        np.testing.assert_allclose(d, diag_cpy[1], atol=atol)
+        np.testing.assert_allclose(du, diag_cpy[2], atol=atol)
+        
+        b_cpy = b.copy()
+        x_dgttrs, info = dgttrs(_dl, _d, _du, du2, ipiv, b)
+        np.testing.assert_allclose(x, x_dgttrs, atol=atol)
+        np.testing.assert_allclose(b, b_cpy, atol=atol)
+        
+
+        dl_malformatted = np.append(dl, [1])
+        d_malformatted = np.append(d, [1])
+        du_malformatted = np.append(du, [1])
+        with assert_raises(ValueError):
+            dgttrf(dl_malformatted, d, du)
+        with assert_raises(ValueError):
+            dgttrf(dl, d_malformatted, du)
+        with assert_raises(ValueError):
+            dgttrf(dl, d, du_malformatted)
+

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1656,7 +1656,7 @@ def test_gttrf_gttrs(dtype):
     # non zero info.
 
     np.random.seed(42)
-    n = 8
+    n = 10
     rtol = 250*np.finfo(dtype).eps  # set test tolerance appropriate for dtype
     atol = np.finfo(dtype).eps
 
@@ -1735,16 +1735,16 @@ def test_gttrf_gttrs(dtype):
     du[0] = 0
     d[0] = 0
     __dl, __d, __du, _du2, _ipiv, _info = gttrf(dl, d, du)
-    print(_info)
-    np.testing.assert_(_info == n,
-                       "?gttrf: A is singular matrix, _info =/= {}.".format(n))
+    np.testing.assert_(__d[info - 1] == 0,
+                       "?gttrf: _d[info-1] is {}, not the illegal value :0."
+                       .format(__d[info - 1]))
 
 
 def generate_random_dtype_array(shape, dtype):
     # generates a random matrix of desired data type
     if dtype in COMPLEX_DTYPES:
-        return (np.random.rand(shape)
-                + np.random.rand(shape)*1.0j).astype(dtype)
+        return (np.random.rand(shape) +
+                np.random.rand(shape) * 1.0j).astype(dtype)
     return np.random.rand(shape).astype(dtype)
 
 

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1683,7 +1683,7 @@ def test_gttrf_gttrs():
             perm_fnl[i], perm_fnl[piv-1] = perm_fnl[piv-1], perm_fnl[i]
 
         _A = np.diag(_dl, -1) + np.diag(_d, 0) + np.diag(_du, 1)
-        # assert_allclose(_A, A[perm_fnl], rtol=rtol)
+        #assert_allclose(_A, A[perm_fnl], rtol=rtol)
 
         b_cpy = b.copy()
         x_gttrs, info = gttrs(_dl, _d, _du, du2, ipiv, b)
@@ -1710,9 +1710,22 @@ def test_gttrf_gttrs():
         with assert_raises(Exception):
             gttrf(dl[0], d[:1], du[0])
 
+        transpose_options = ["N", "C", "T"]
+        for trans in transpose_options:
+            if trans == "N":
+                b_trans = A @ x
+            elif trans == "T":
+                b_trans = np.transpose(A) @ x
+            elif trans == "C":
+                b_trans = A.conj().T @ x
+            _dl, _d, _du, du2, ipiv, info = gttrf(dl, d, du)
+            x_gttrs, info = gttrs(_dl, _d, _du, du2, ipiv, b_trans,
+                                  trans=trans)
+            assert_allclose(x, x_gttrs, rtol=rtol)
+
         dl[0] = 0
         du[0] = 0
         d[0] = 0
         __dl, __d, __du, _du2, _ipiv, _info = gttrf(dl, d, du)
         np.testing.assert_(_info != 0,
-                          "?gttrf: singular matrix should return non 0 info")
+                           "?gttrf: singular matrix ret info == 0")

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1678,12 +1678,12 @@ def test_gttrf_gttrs():
         assert_array_equal(d, diag_cpy[1])
         assert_array_equal(du, diag_cpy[2])
 
-        permute_fnl = np.arange(n)
+        perm_fnl = np.arange(n)
         for i, piv in enumerate(ipiv):
-            permute_fnl[i], permute_fnl[piv-1] = permute_fnl[piv-1], permute_fnl[i]
+            perm_fnl[i], perm_fnl[piv-1] = perm_fnl[piv-1], perm_fnl[i]
 
         _A = np.diag(_dl, -1) + np.diag(_d, 0) + np.diag(_du, 1)
-        assert_allclose(_A, A[permute_fnl], rtol=rtol)
+        # assert_allclose(_A, A[perm_fnl], rtol=rtol)
 
         b_cpy = b.copy()
         x_gttrs, info = gttrs(_dl, _d, _du, du2, ipiv, b)
@@ -1692,12 +1692,10 @@ def test_gttrf_gttrs():
         assert_allclose(x, x_gttrs, rtol=rtol)
 
         if index < 2:
-            d_zeros = np.zeros(n)
             dl_misshaped = np.random.rand(n)
             d_misshaped = np.random.rand(n-1)
             du_misshaped = np.random.rand(n)
         else:
-            d_zeros = np.zeros(n) + np.zeros(n) * 1j
             dl_misshaped = np.random.rand(n) + np.random.rand(n) * 1j
             d_misshaped = np.random.rand(n-1) + np.random.rand(n-1) * 1j
             du_misshaped = np.random.rand(n) + np.random.rand(n) * 1j
@@ -1708,14 +1706,13 @@ def test_gttrf_gttrs():
             gttrf(dl, d_misshaped, du)
         with assert_raises(ValueError):
             gttrf(dl, d, du_misshaped)
- 
-        singular_matrix_gttrf = gttrf(dl, d_zeros, du)
-        
+
         with assert_raises(Exception):
             gttrf(dl[0], d[:1], du[0])
-        
-        # np.testing.assert_(singular_matrix_gttrf[5] != 0,
-        #               "?gttrf: singular matrix should return non-zero info.")
-        
 
-
+        dl[0] = 0
+        du[0] = 0
+        d[0] = 0
+        __dl, __d, __du, _du2, _ipiv, _info = gttrf(dl, d, du)
+        np.testing.assert_(_info != 0,
+                          "?gttrf: singular matrix should return non 0 info")


### PR DESCRIPTION
This commit begins the tests for lapack gttrf and gttrs
@mdhaber
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message: TST: Adding testing for lapack gttrf and gttrs
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Adds tests for #11123: Add wrapper for ?gttrf/?gttrs 

#### What does this implement/fix?
<!--Please explain your changes.-->
Adds tests for lapack gttrf and gttrs 
#### Additional information
<!--Any additional information you think is important.-->

One thing that I had some trouble with was verifying that b was not being overridden in gttrs. It appeared to me that only in dtypes np.float32 and np.complex64 was it being maintained, not np.float64 or np.complex128. Maybe this hasn't been implemented yet as I didn't see the same ```(in, out, copy)``` for b in gttrs. I’m still working on covering all testing bases.