### PR TITLE
Add tests for ptsvx

### DIFF
--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1654,3 +1654,88 @@ def test_getc2_gesc2():
         else:
             assert_array_almost_equal(desired_cplx.astype(dtype),
                                       x/scale, decimal=4)
+def generate_random_dtype_array(shape, dtype):
+    # generates a random matrix of desired data type of shape
+    if dtype in COMPLEX_DTYPES:
+        return (np.random.rand(*shape)
+                + np.random.rand(*shape)*1.0j).astype(dtype)
+    return np.random.rand(*shape).astype(dtype)
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("fact", ("F", "N"))
+
+def test_ptsvx(dtype,fact):
+    np.random.seed(42)
+    # set test tolerance appropriate for dtype
+    rtol = 250*np.finfo(dtype).eps
+    atol = 100*np.finfo(dtype).eps
+    # obtain routine
+    ptsvx = get_lapack_funcs('ptsvx', dtype=dtype)
+    # n is the length diagonal of A
+    n = 5
+    # create diagonals according to size and dtype
+    if dtype in REAL_DTYPES:
+        # add 2 so that the matrix will be diagonally dominant
+        d = generate_random_dtype_array((n,), dtype) + 2
+    else:
+        # diagonal d should always be real.
+        # for complex add 4 so it will be dominant
+        d = generate_random_dtype_array((n,), DTYPES[1]) + 4
+    # diagonal e may be real or complex.
+    e = generate_random_dtype_array(n-1, dtype)
+    # form matrix A from d and e
+    A = np.diag(d) + np.diag(e, -1) + np.diag(e, 1)
+    # create random solution x
+    x_soln = generate_random_dtype_array((n,2), dtype)
+    # now create a b based on these
+    b = A @ x_soln
+    # determine if de, df, should be null or based on pttrf
+    if fact == "N":
+        de = None
+        df = None
+    else:
+        pttrf = get_lapack_funcs('pttrf', dtype=dtype)
+        df, fe, info = pttrf(d, e)
+        
+    # solve using routine 
+    x, df, ef, rcond, ferr, berr, info  = ptsvx(d, e, b, fact=fact, df=df, de=de)
+    assert_(info == 0, "info should be 0 but is {}.".format(info))
+    assert_array_almost_equal(x_soln, x)
+    
+    # test that the factors from ptsvx can be recombined to make A
+    L = np.diag(ef, -1) + np.diag(np.ones(n))
+    D = np.diag(df)
+    assert_allclose(A, L@D@(np.transpose(L)), rtol=rtol, atol=atol)
+    
+    # assert that the outputs are of correct type or shape
+    # rcond should be a scalar
+    assert_(hasattr(rcond, "__len__"),
+            "rcond should be scalar but is {}").format(rcond)
+    # ferr should be length of # of cols in x
+    assert_(ferr.shape == (n,), "ferr.shape is {} but shoud be ({},)"
+            .format(ferr.shape, x_soln.shape))
+    # berr should be length of # of cols in x
+    assert_(berr.shape == (n,), "berr.shape is {} but shoud be ({},)"
+            .format(berr.shape, n))
+
+    # test with malformatted array sizes
+    with assert_raises(Exception):
+        ptsvx(d[:-1], e, b, fact=fact, df=df, de=de)
+    with assert_raises(Exception):
+        ptsvx(d, e[:-1], b, fact=fact, df=df, de=de)
+    with assert_raises(Exception):
+        ptsvx(d, e, b[:-1], fact=fact, df=df, de=de)
+        
+    # test with singular matrix
+    
+    # test with non spd matrix
+    x, df, ef, rcond, ferr, berr, info = ptsvx(d, e+2, b, fact=fact, df=df, de=de)
+
+    
+    # It might be cool to create an example for which the matrix is numerically - but not exactly - singular to see if we can get info==N+1
+    
+    
+    
+    
+    
+

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1645,3 +1645,88 @@ def test_getc2_gesc2():
         else:
             assert_array_almost_equal(desired_cplx.astype(dtype),
                                       x/scale, decimal=4)
+def generate_random_dtype_array(shape, dtype):
+    # generates a random matrix of desired data type of shape
+    if dtype in COMPLEX_DTYPES:
+        return (np.random.rand(*shape)
+                + np.random.rand(*shape)*1.0j).astype(dtype)
+    return np.random.rand(*shape).astype(dtype)
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("fact", ("F", "N"))
+
+def test_ptsvx(dtype,fact):
+    np.random.seed(42)
+    # set test tolerance appropriate for dtype
+    rtol = 250*np.finfo(dtype).eps
+    atol = 100*np.finfo(dtype).eps
+    # obtain routine
+    ptsvx = get_lapack_funcs('ptsvx', dtype=dtype)
+    # n is the length diagonal of A
+    n = 5
+    # create diagonals according to size and dtype
+    if dtype in REAL_DTYPES:
+        # add 2 so that the matrix will be diagonally dominant
+        d = generate_random_dtype_array((n,), dtype) + 2
+    else:
+        # diagonal d should always be real.
+        # for complex add 4 so it will be dominant
+        d = generate_random_dtype_array((n,), DTYPES[1]) + 4
+    # diagonal e may be real or complex.
+    e = generate_random_dtype_array(n-1, dtype)
+    # form matrix A from d and e
+    A = np.diag(d) + np.diag(e, -1) + np.diag(e, 1)
+    # create random solution x
+    x_soln = generate_random_dtype_array((n,2), dtype)
+    # now create a b based on these
+    b = A @ x_soln
+    # determine if de, df, should be null or based on pttrf
+    if fact == "N":
+        de = None
+        df = None
+    else:
+        pttrf = get_lapack_funcs('pttrf', dtype=dtype)
+        df, fe, info = pttrf(d, e)
+        
+    # solve using routine 
+    x, df, ef, rcond, ferr, berr, info  = ptsvx(d, e, b, fact=fact, df=df, de=de)
+    assert_(info == 0, "info should be 0 but is {}.".format(info))
+    assert_array_almost_equal(x_soln, x)
+    
+    # test that the factors from ptsvx can be recombined to make A
+    L = np.diag(ef, -1) + np.diag(np.ones(n))
+    D = np.diag(df)
+    assert_allclose(A, L@D@(np.transpose(L)), rtol=rtol, atol=atol)
+    
+    # assert that the outputs are of correct type or shape
+    # rcond should be a scalar
+    assert_(hasattr(rcond, "__len__"),
+            "rcond should be scalar but is {}").format(rcond)
+    # ferr should be length of # of cols in x
+    assert_(ferr.shape == (n,), "ferr.shape is {} but shoud be ({},)"
+            .format(ferr.shape, x_soln.shape))
+    # berr should be length of # of cols in x
+    assert_(berr.shape == (n,), "berr.shape is {} but shoud be ({},)"
+            .format(berr.shape, n))
+
+    # test with malformatted array sizes
+    with assert_raises(Exception):
+        ptsvx(d[:-1], e, b, fact=fact, df=df, de=de)
+    with assert_raises(Exception):
+        ptsvx(d, e[:-1], b, fact=fact, df=df, de=de)
+    with assert_raises(Exception):
+        ptsvx(d, e, b[:-1], fact=fact, df=df, de=de)
+        
+    # test with singular matrix
+    
+    # test with non spd matrix
+    x, df, ef, rcond, ferr, berr, info = ptsvx(d, e+2, b, fact=fact, df=df, de=de)
+
+    
+    # It might be cool to create an example for which the matrix is numerically - but not exactly - singular to see if we can get info==N+1
+    
+    
+    
+    
+    
+

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1664,13 +1664,14 @@ def generate_random_dtype_array(shape, dtype):
     return np.random.rand(*shape).astype(dtype)
 
 
-@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("dtype,realtype", zip(DTYPES, REAL_DTYPES
+                                               + REAL_DTYPES))
 @pytest.mark.parametrize("fact,df_de_lambda",
                          [("F",
                            lambda d, e:get_lapack_funcs('pttrf',
                                                         dtype=e.dtype)(d, e)),
                           ("N", lambda d, e: (None, None, None))])
-def test_ptsvx(dtype, fact, df_de_lambda):
+def test_ptsvx(dtype, realtype, fact, df_de_lambda):
     '''
     TODO: let's see what the actual type of rcond is so that we can test for
     that specifcially
@@ -1687,17 +1688,11 @@ def test_ptsvx(dtype, fact, df_de_lambda):
     ptsvx = get_lapack_funcs('ptsvx', dtype=dtype)
     n = 5
     # create diagonals according to size and dtype
-    if dtype in REAL_DTYPES:
-        # add 2 so that the matrix will be diagonally dominant
-        d = generate_random_dtype_array((n,), dtype=dtype) + 2
-    else:
-        # Per lapack documentation, diagonal d should always be real.
-        # for complex add 4 so it will be dominant
-        d = generate_random_dtype_array((n,), DTYPES[1]) + 4
+    d = generate_random_dtype_array((n,), realtype) + 4
     # diagonal e may be real or complex.
     e = generate_random_dtype_array((n-1,), dtype)
     # form matrix A from d and e
-    A = np.diag(d) + np.diag(e, -1) + np.diag(e, 1)
+    A = np.diag(d) + np.diag(e, -1) + np.diag(np.conj(e), 1)
     # create random solution x
     x_soln = generate_random_dtype_array((n, 2), dtype=dtype)
     b = A @ x_soln
@@ -1709,7 +1704,7 @@ def test_ptsvx(dtype, fact, df_de_lambda):
     diag_cpy = [d.copy(), e.copy(), b.copy()]
 
     # solve using routine
-    x, df, ef, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact,
+    df, ef, x, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact,
                                                df=df, ef=ef)
     # d, e, and b should be unmodified
     assert_array_equal(d, diag_cpy[0])
@@ -1722,63 +1717,98 @@ def test_ptsvx(dtype, fact, df_de_lambda):
     # test that the factors from ptsvx can be recombined to make A
     L = np.diag(ef, -1) + np.diag(np.ones(n))
     D = np.diag(df)
-    assert_allclose(A, L@D@(np.transpose(L)), rtol=rtol, atol=atol)
+    assert_allclose(A, L@D@(np.conj(L).T), rtol=rtol, atol=atol)
 
     # assert that the outputs are of correct type or shape
     # rcond should be a scalar
-    assert_(hasattr(rcond, "__len__"),
-            "rcond should be scalar but is {}").format(rcond)
+    assert not hasattr(rcond, "__len__"), \
+        "rcond should be scalar but is {}".format(rcond)
     # ferr should be length of # of cols in x
-    assert_(ferr.shape == (n,), "ferr.shape is {} but shoud be ({},)"
-            .format(ferr.shape, x_soln.shape))
+    assert_(ferr.shape == (2,), "ferr.shape is {} but shoud be ({},)"
+            .format(ferr.shape, x_soln.shape[1]))
     # berr should be length of # of cols in x
-    assert_(berr.shape == (n,), "berr.shape is {} but shoud be ({},)"
-            .format(berr.shape, n))
+    assert_(berr.shape == (2,), "berr.shape is {} but shoud be ({},)"
+            .format(berr.shape, x_soln.shape[1]))
+
+@pytest.mark.parametrize("dtype,realtype", zip(DTYPES, REAL_DTYPES
+                                               + REAL_DTYPES))
+@pytest.mark.parametrize("fact,df_de_lambda",
+                         [("F",
+                           lambda d, e:get_lapack_funcs('pttrf',
+                                                        dtype=e.dtype)(d, e)),
+                          ("N", lambda d, e: (None, None, None))])
+def test_ptsvx_error_raise_errors(dtype, realtype, fact, df_de_lambda):
+    ptsvx = get_lapack_funcs('ptsvx', dtype=dtype)
+    n = 5
+    # create diagonals according to size and dtype
+    d = generate_random_dtype_array((n,), realtype) + 4
+    # diagonal e may be real or complex.
+    e = generate_random_dtype_array((n-1,), dtype)
+    # form matrix A from d and e
+    A = np.diag(d) + np.diag(e, -1) + np.diag(np.conj(e), 1)
+    # create random solution x
+    x_soln = generate_random_dtype_array((n, 2), dtype=dtype)
+    b = A @ x_soln
+
+    # use lambda to determine what df, ef are
+    df, ef, info = df_de_lambda(d, e)
 
     # test with malformatted array sizes
     with assert_raises(ValueError):
         ptsvx(d[:-1], e, b, fact=fact, df=df, ef=ef)
     with assert_raises(ValueError):
         ptsvx(d, e[:-1], b, fact=fact, df=df, ef=ef)
-    with assert_raises(ValueError):
-        ptsvx(d, e, b[:-1], fact=fact, df=df, ef=ef)
-    '''come back to later if doesnt work to check for nonzero info'''
-    # test with non spd matrix
-    x, df, ef, rcond, ferr, berr, info = ptsvx(d, e+2, b, fact=fact, df=df,
-                                               ef=ef)
+    df, ef, x, rcond, ferr, berr, info = ptsvx(d, e, b[:-1], fact=fact,
+                                               df=df, ef=ef)
+    assert info < 0
 
-    # test with singular matrix
-    # no need to test with fact "T" since ?pttrf already tests for these.
+
+@pytest.mark.parametrize("dtype,realtype", zip(DTYPES, REAL_DTYPES
+                                               + REAL_DTYPES))
+@pytest.mark.parametrize("fact,df_de_lambda",
+                         [("F",
+                           lambda d, e:get_lapack_funcs('pttrf',
+                                                        dtype=e.dtype)(d, e)),
+                          ("N", lambda d, e: (None, None, None))])
+def test_ptsvx_non_SPD_singular(dtype, realtype, fact, df_de_lambda):
+
+    ptsvx = get_lapack_funcs('ptsvx', dtype=dtype)
+    n = 5
+    # create diagonals according to size and dtype
+    d = generate_random_dtype_array((n,), realtype) + 4
+    # diagonal e may be real or complex.
+    e = generate_random_dtype_array((n-1,), dtype)
+    # form matrix A from d and e
+    A = np.diag(d) + np.diag(e, -1) + np.diag(np.conj(e), 1)
+    # create random solution x
+    x_soln = generate_random_dtype_array((n, 2), dtype=dtype)
+    b = A @ x_soln
+
+    # use lambda to determine what df, ef are
+    df, ef, info = df_de_lambda(d, e)
+    # test with non spd matrix
+
     if fact == "N":
-        d[0] = 0
+        d[3] = 0
         # obtain new df, ef
         df, ef, info = df_de_lambda(d, e)
         # solve using routine
-        x, df, ef, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact, df=df,
-                                                   ef=ef)
+        df, ef, x, rcond, ferr, berr, info = ptsvx(d, e, b)
         # test for the singular matrix.
-        assert_(d[info - 1] == 0,
-                "?ptsvx: d[info-1] is {}, not the illegal value"
-                .format(d[info - 1]))
+        assert info > 0
 
         # non SPD matrix
-        d = generate_random_dtype_array(n, dtype)
-        x, df, ef, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact, df=df,
-                                                   ef=ef)
-        assert_(np.linalg.norm(d[info]) < 2 * np.linalg.norm(e[info]),
-                "?ptsvx: idx {} of d should < e but are: {}, {} ".format(
-                   info, np.linalg.norm(d[info]), np.linalg.norm(e[info])))
+        d = generate_random_dtype_array((n,), realtype)
+        df, ef, x, rcond, ferr, berr, info = ptsvx(d, e, b)
+        assert info > 0
     else:
         # assuming that someone is using a singular factorization
-        df, ef = df_de_lambda(d, e)
+        df, ef, info = df_de_lambda(d, e)
         df[0] = 0
         ef[0] = 0
-        x, df, ef, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact,
+        df, ef, x, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact,
                                                    df=df, ef=ef)
-        # info should not be zero and should provide index of illegal value
-        assert_(d[info - 1] == 0,
-                "?ptsvx: _d[info-1] is {}, not the illegal value"
-                .format(d[info - 1]))
+        assert info > 0
 
     # It might be cool to create an example for which the matrix is
     # numerically - but not exactly - singular to see if we can get info==N+1
@@ -1793,13 +1823,14 @@ def test_ptsvx(dtype, fact, df_de_lambda):
                                      [-1, 6], [3, -5]])),
                           (np.array([16, 41, 46, 21]),
                            np.array([16 + 16j, 18 - 9j, 1 - 4j]),
-                           np.array([[64 - 16j, -16 - 32j],
-                                     [93 - 62j, 61 - 66j],
+                           np.array([[64 + 16j, -16 - 32j],
+                                     [93 + 62j, 61 - 66j],
                                      [78 - 80j, 71 - 74j],
                                      [14 - 27j, 35 + 15j]]),
                            np.array([[2 + 1j, -3 - 2j],
-                                     [1 + 1j, 1 + 1j], [1 - 2j, 1 - 2j],
-                                     [1 - 1j, 2 - 1j]]))])
+                                     [1 + 1j, 1 + 1j],
+                                     [1 - 2j, 1 - 2j],
+                                     [1 - 1j, 2 + 1j]]))])
 def test_ptsvx_NAG(d, e, b, x):
     '''
     TODO: On nag manual there are berr vals that are exactly zero.
@@ -1816,6 +1847,6 @@ def test_ptsvx_NAG(d, e, b, x):
     # obtain routine with correct type based on e.dtype
     ptsvx = get_lapack_funcs('ptsvx', dtype=e.dtype)
     # solve using routine
-    x_ptsvx, df, ef, rcond, ferr, berr, info = ptsvx(d, e, b, fact="N")
+    df, ef, x_ptsvx, rcond, ferr, berr, info = ptsvx(d, e, b)
     # determine ptsvx's solution and x are the same.
     assert_array_almost_equal(x, x_ptsvx)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1673,9 +1673,6 @@ def generate_random_dtype_array(shape, dtype):
                           ("N", lambda d, e: (None, None, None))])
 def test_ptsvx(dtype, realtype, fact, df_de_lambda):
     '''
-    TODO: let's see what the actual type of rcond is so that we can test for
-    that specifcially
-
     This tests the ?ptsvx lapack routine wrapper to solve a random system
     Ax = b for all dtypes and input variations. Tests for: unmodified
     input parameters, fact options, incompatible matrix shapes raise an error,
@@ -1689,11 +1686,8 @@ def test_ptsvx(dtype, realtype, fact, df_de_lambda):
     n = 5
     # create diagonals according to size and dtype
     d = generate_random_dtype_array((n,), realtype) + 4
-    # diagonal e may be real or complex.
     e = generate_random_dtype_array((n-1,), dtype)
-    # form matrix A from d and e
     A = np.diag(d) + np.diag(e, -1) + np.diag(np.conj(e), 1)
-    # create random solution x
     x_soln = generate_random_dtype_array((n, 2), dtype=dtype)
     b = A @ x_soln
 
@@ -1742,11 +1736,8 @@ def test_ptsvx_error_raise_errors(dtype, realtype, fact, df_de_lambda):
     n = 5
     # create diagonals according to size and dtype
     d = generate_random_dtype_array((n,), realtype) + 4
-    # diagonal e may be real or complex.
     e = generate_random_dtype_array((n-1,), dtype)
-    # form matrix A from d and e
     A = np.diag(d) + np.diag(e, -1) + np.diag(np.conj(e), 1)
-    # create random solution x
     x_soln = generate_random_dtype_array((n, 2), dtype=dtype)
     b = A @ x_soln
 
@@ -1760,6 +1751,7 @@ def test_ptsvx_error_raise_errors(dtype, realtype, fact, df_de_lambda):
         ptsvx(d, e[:-1], b, fact=fact, df=df, ef=ef)
     df, ef, x, rcond, ferr, berr, info = ptsvx(d, e, b[:-1], fact=fact,
                                                df=df, ef=ef)
+    # this info returns -9
     assert info < 0
 
 
@@ -1776,17 +1768,13 @@ def test_ptsvx_non_SPD_singular(dtype, realtype, fact, df_de_lambda):
     n = 5
     # create diagonals according to size and dtype
     d = generate_random_dtype_array((n,), realtype) + 4
-    # diagonal e may be real or complex.
     e = generate_random_dtype_array((n-1,), dtype)
-    # form matrix A from d and e
     A = np.diag(d) + np.diag(e, -1) + np.diag(np.conj(e), 1)
-    # create random solution x
     x_soln = generate_random_dtype_array((n, 2), dtype=dtype)
     b = A @ x_soln
 
     # use lambda to determine what df, ef are
     df, ef, info = df_de_lambda(d, e)
-    # test with non spd matrix
 
     if fact == "N":
         d[3] = 0
@@ -1795,12 +1783,12 @@ def test_ptsvx_non_SPD_singular(dtype, realtype, fact, df_de_lambda):
         # solve using routine
         df, ef, x, rcond, ferr, berr, info = ptsvx(d, e, b)
         # test for the singular matrix.
-        assert info > 0
+        assert info > 0 and info <= n
 
         # non SPD matrix
         d = generate_random_dtype_array((n,), realtype)
         df, ef, x, rcond, ferr, berr, info = ptsvx(d, e, b)
-        assert info > 0
+        assert info > 0 and info <= n
     else:
         # assuming that someone is using a singular factorization
         df, ef, info = df_de_lambda(d, e)
@@ -1808,7 +1796,7 @@ def test_ptsvx_non_SPD_singular(dtype, realtype, fact, df_de_lambda):
         ef[0] = 0
         df, ef, x, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact,
                                                    df=df, ef=ef)
-        assert info > 0
+        assert info > 0 and info <= n
 
     # It might be cool to create an example for which the matrix is
     # numerically - but not exactly - singular to see if we can get info==N+1

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1654,6 +1654,8 @@ def test_getc2_gesc2():
         else:
             assert_array_almost_equal(desired_cplx.astype(dtype),
                                       x/scale, decimal=4)
+
+
 def generate_random_dtype_array(shape, dtype):
     # generates a random matrix of desired data type of shape
     if dtype in COMPLEX_DTYPES:
@@ -1661,14 +1663,26 @@ def generate_random_dtype_array(shape, dtype):
                 + np.random.rand(*shape)*1.0j).astype(dtype)
     return np.random.rand(*shape).astype(dtype)
 
-@pytest.mark.parametrize("dtype", DTYPES)
-@pytest.mark.parametrize("fact", ("F", "N"))
 
-def test_ptsvx(dtype,fact):
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("fact,de_df_lambda",
+                         [("F", lambda d, e:get_lapack_funcs('pttrf',
+                                                             dtype=e.dtype)),
+                          ("N", lambda d, e: (None, None, None))])
+def test_ptsvx(dtype, fact, de_df_lambda):
+    '''
+    TODO: let's see what the actual type of rcond is so that we can test for
+    that specifcially
+
+    This tests the ?ptsvx lapack routine wrapper to solve a random system
+    Ax = b for all dtypes and input variations. Tests for: unmodified
+    input parameters, fact options, incompatible matrix shapes raise an error,
+    and singular matrices return info of illegal value.
+    '''
     np.random.seed(42)
     # set test tolerance appropriate for dtype
-    rtol = 250*np.finfo(dtype).eps
-    atol = 100*np.finfo(dtype).eps
+    rtol = 250 * np.finfo(dtype).eps
+    atol = 100 * np.finfo(dtype).eps
     # obtain routine
     ptsvx = get_lapack_funcs('ptsvx', dtype=dtype)
     # n is the length diagonal of A
@@ -1676,7 +1690,7 @@ def test_ptsvx(dtype,fact):
     # create diagonals according to size and dtype
     if dtype in REAL_DTYPES:
         # add 2 so that the matrix will be diagonally dominant
-        d = generate_random_dtype_array((n,), dtype) + 2
+        d = generate_random_dtype_array((n,), dtype=dtype) + 2
     else:
         # diagonal d should always be real.
         # for complex add 4 so it will be dominant
@@ -1686,27 +1700,36 @@ def test_ptsvx(dtype,fact):
     # form matrix A from d and e
     A = np.diag(d) + np.diag(e, -1) + np.diag(e, 1)
     # create random solution x
-    x_soln = generate_random_dtype_array((n,2), dtype)
+    x_soln = generate_random_dtype_array((n, 2), dtype=dtype)
     # now create a b based on these
     b = A @ x_soln
-    # determine if de, df, should be null or based on pttrf
-    if fact == "N":
-        de = None
-        df = None
+
+    # use lambda to determine what df, ef are
+    # (parametrized to either be null or result of ?pttrf)
+    df, ef, info = de_df_lambda(d, e)
+
+    diag_cpy = [d.copy(), e.copy(), b.copy()]
+
+    # solve using routine
+    if fact == "F":
+        x, df, ef, rcond, ferr, berr, info = ptsvx(None, None, b, fact=fact,
+                                                   df=df, ef=ef)
     else:
-        pttrf = get_lapack_funcs('pttrf', dtype=dtype)
-        df, fe, info = pttrf(d, e)
-        
-    # solve using routine 
-    x, df, ef, rcond, ferr, berr, info  = ptsvx(d, e, b, fact=fact, df=df, de=de)
+        x, df, ef, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact,
+                                                   df=df, ef=ef)
+    # d, e, and b should be unmodified
+    assert_array_equal(d, diag_cpy[0])
+    assert_array_equal(e, diag_cpy[1])
+    assert_array_equal(b, diag_cpy[2])
+
     assert_(info == 0, "info should be 0 but is {}.".format(info))
     assert_array_almost_equal(x_soln, x)
-    
+
     # test that the factors from ptsvx can be recombined to make A
     L = np.diag(ef, -1) + np.diag(np.ones(n))
     D = np.diag(df)
     assert_allclose(A, L@D@(np.transpose(L)), rtol=rtol, atol=atol)
-    
+
     # assert that the outputs are of correct type or shape
     # rcond should be a scalar
     assert_(hasattr(rcond, "__len__"),
@@ -1720,22 +1743,92 @@ def test_ptsvx(dtype,fact):
 
     # test with malformatted array sizes
     with assert_raises(Exception):
-        ptsvx(d[:-1], e, b, fact=fact, df=df, de=de)
+        ptsvx(d[:-1], e, b, fact=fact, df=df, ef=ef)
     with assert_raises(Exception):
-        ptsvx(d, e[:-1], b, fact=fact, df=df, de=de)
+        ptsvx(d, e[:-1], b, fact=fact, df=df, ef=ef)
     with assert_raises(Exception):
-        ptsvx(d, e, b[:-1], fact=fact, df=df, de=de)
-        
-    # test with singular matrix
-    
+        ptsvx(d, e, b[:-1], fact=fact, df=df, ef=ef)
+
     # test with non spd matrix
-    x, df, ef, rcond, ferr, berr, info = ptsvx(d, e+2, b, fact=fact, df=df, de=de)
+    x, df, ef, rcond, ferr, berr, info = ptsvx(d, e+2, b, fact=fact, df=df,
+                                               ef=ef)
 
-    
-    # It might be cool to create an example for which the matrix is numerically - but not exactly - singular to see if we can get info==N+1
-    
-    
-    
-    
-    
+    # test with singular matrix
+    # no need to test with fact "T" since ?pttrf already tests for these.
+    if fact == "N":
+        d[0] = 0
+        # obtain new df, ef
+        df, ef, info = de_df_lambda(d, e)
+        # solve using routine
+        x, df, ef, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact, df=df,
+                                                   ef=ef)
+        # test for the singular matrix.
+        assert_(d[info - 1] == 0,
+                           "?ptsvx: d[info-1] is {}, not the illegal value"
+                           .format(d[info - 1]))
 
+        # non SPD matrix
+        d = generate_random_dtype_array(n, dtype)
+        x, df, ef, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact, df=df,
+                                                   ef=ef)
+        assert_(np.linalg.norm(d[info]) < 2 * np.linalg.norm(e[info]),
+                "?ptsvx: idx {} of d should < e but are: {}, {} ".format(
+                   info, np.linalg.norm(d[info]), np.linalg.norm(e[info])))
+    else:
+        # assuming that someone is using a singular factorization
+        df, ef = de_df_lambda(d, e)
+        df[0] = 0
+        ef[0] = 0
+        x, df, ef, rcond, ferr, berr, info = ptsvx(None, None, b, fact=fact,
+                                                   df=df, ef=ef)
+        # info should not be zero and should provide index of illegal value
+        assert_(d[info - 1] == 0,
+                           "?ptsvx: _d[info-1] is {}, not the illegal value"
+                           .format(d[info - 1]))
+
+
+    # It might be cool to create an example for which the matrix is
+    # numerically - but not exactly - singular to see if we can get info==N+1
+
+
+@pytest.mark.parametrize('d,e,b,x', [(np.array([4, 10, 29, 25, 5]),
+                                      np.array([-2, -6, 15, 8]),
+                                      np.array([[6, 10],
+                                                [9, 4],
+                                                [2, 9],
+                                                [14, 65],
+                                                [7, 23]]),
+                                      np.array([[2.5, 2]],
+                                               [2, -1],
+                                               [1, -3],
+                                               [-1, 6],
+                                               [3, -5])),
+                                     (np.array([16, 41, 46, 21]),
+                                      np.array([16 + 16j, 18 - 9j, 1 - 4j]),
+                                      np.array([[64 - 16j, -16 - 32j],
+                                                [93 - 62j, 61 - 66j],
+                                                [78 - 80j, 71 - 74j],
+                                                [14 - 27j, 35 + 15j]]),
+                                      np.array([[2 + 1j, -3 - 2j]],
+                                               [1 + 1j, 1 + 1j],
+                                               [1 - 2j, 1 - 2j],
+                                               [1 - 1j, 2 - 1j]))])
+def test_ptsvx_NAG(d, e, b, x):
+    '''
+    TODO: On nag manual there are berr vals that are exactly zero.
+        - why would it be zero, shouldn't it not be?
+        - test idea to just see if nearby zero.
+
+    Tests real and complex NAG examples: f07jbf, f07jpf
+    https://www.nag.com/numeric/fl/nagdoc_fl26.2/html/f07/f07jbf.html
+    https://www.nag.com/numeric/fl/nagdoc_fl26.2/html/f07/f07jpf.html
+    '''
+    # test that it is close to zero, ask kai about why it is exactly zero
+    # (not supposed to be exactly zero, or at least shouldnt be)
+
+    # obtain routine with correct type based on e.dtype
+    ptsvx = get_lapack_funcs('ptsvx', dtype=e.dtype)
+    # solve using routine
+    x_ptsvx, df, ef, rcond, ferr, berr, info = ptsvx(d, e, b, fact="N")
+    # determine ptsvx's solution and x are the same.
+    assert_array_almost_equal(x, x_ptsvx)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1666,8 +1666,9 @@ def generate_random_dtype_array(shape, dtype):
 
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("fact,df_de_lambda",
-                         [("F", lambda d, e:get_lapack_funcs('pttrf',
-                                                             dtype=e.dtype)),
+                         [("F",
+                           lambda d, e:get_lapack_funcs('pttrf',
+                                                        dtype=e.dtype)(d, e)),
                           ("N", lambda d, e: (None, None, None))])
 def test_ptsvx(dtype, fact, df_de_lambda):
     '''
@@ -1683,9 +1684,7 @@ def test_ptsvx(dtype, fact, df_de_lambda):
     # set test tolerance appropriate for dtype
     rtol = 250 * np.finfo(dtype).eps
     atol = 100 * np.finfo(dtype).eps
-    # obtain routine
     ptsvx = get_lapack_funcs('ptsvx', dtype=dtype)
-    # n is the length diagonal of A
     n = 5
     # create diagonals according to size and dtype
     if dtype in REAL_DTYPES:
@@ -1701,13 +1700,12 @@ def test_ptsvx(dtype, fact, df_de_lambda):
     A = np.diag(d) + np.diag(e, -1) + np.diag(e, 1)
     # create random solution x
     x_soln = generate_random_dtype_array((n, 2), dtype=dtype)
-    # now create a b based on these
     b = A @ x_soln
 
     # use lambda to determine what df, ef are
-    # (parametrized to either be null or result of ?pttrf)
     df, ef, info = df_de_lambda(d, e)
 
+    # create copy to later test that they are unmodified
     diag_cpy = [d.copy(), e.copy(), b.copy()]
 
     # solve using routine
@@ -1775,7 +1773,7 @@ def test_ptsvx(dtype, fact, df_de_lambda):
         df, ef = df_de_lambda(d, e)
         df[0] = 0
         ef[0] = 0
-        x, df, ef, rcond, ferr, berr, info = ptsvx(None, None, b, fact=fact,
+        x, df, ef, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact,
                                                    df=df, ef=ef)
         # info should not be zero and should provide index of illegal value
         assert_(d[info - 1] == 0,
@@ -1786,28 +1784,22 @@ def test_ptsvx(dtype, fact, df_de_lambda):
     # numerically - but not exactly - singular to see if we can get info==N+1
 
 
-@pytest.mark.parametrize('d,e,b,x', [(np.array([4, 10, 29, 25, 5]),
-                                      np.array([-2, -6, 15, 8]),
-                                      np.array([[6, 10],
-                                                [9, 4],
-                                                [2, 9],
-                                                [14, 65],
-                                                [7, 23]]),
-                                      np.array([[2.5, 2]],
-                                               [2, -1],
-                                               [1, -3],
-                                               [-1, 6],
-                                               [3, -5])),
-                                     (np.array([16, 41, 46, 21]),
-                                      np.array([16 + 16j, 18 - 9j, 1 - 4j]),
-                                      np.array([[64 - 16j, -16 - 32j],
-                                                [93 - 62j, 61 - 66j],
-                                                [78 - 80j, 71 - 74j],
-                                                [14 - 27j, 35 + 15j]]),
-                                      np.array([[2 + 1j, -3 - 2j]],
-                                               [1 + 1j, 1 + 1j],
-                                               [1 - 2j, 1 - 2j],
-                                               [1 - 1j, 2 - 1j]))])
+@pytest.mark.parametrize('d,e,b,x',
+                         [(np.array([4, 10, 29, 25, 5]),
+                           np.array([-2, -6, 15, 8]),
+                           np.array([[6, 10], [9, 4], [2, 9], [14, 65],
+                                     [7, 23]]),
+                           np.array([[2.5, 2], [2, -1], [1, -3],
+                                     [-1, 6], [3, -5]])),
+                          (np.array([16, 41, 46, 21]),
+                           np.array([16 + 16j, 18 - 9j, 1 - 4j]),
+                           np.array([[64 - 16j, -16 - 32j],
+                                     [93 - 62j, 61 - 66j],
+                                     [78 - 80j, 71 - 74j],
+                                     [14 - 27j, 35 + 15j]]),
+                           np.array([[2 + 1j, -3 - 2j],
+                                     [1 + 1j, 1 + 1j], [1 - 2j, 1 - 2j],
+                                     [1 - 1j, 2 - 1j]]))])
 def test_ptsvx_NAG(d, e, b, x):
     '''
     TODO: On nag manual there are berr vals that are exactly zero.

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1665,11 +1665,11 @@ def generate_random_dtype_array(shape, dtype):
 
 
 @pytest.mark.parametrize("dtype", DTYPES)
-@pytest.mark.parametrize("fact,de_df_lambda",
+@pytest.mark.parametrize("fact,df_de_lambda",
                          [("F", lambda d, e:get_lapack_funcs('pttrf',
                                                              dtype=e.dtype)),
                           ("N", lambda d, e: (None, None, None))])
-def test_ptsvx(dtype, fact, de_df_lambda):
+def test_ptsvx(dtype, fact, df_de_lambda):
     '''
     TODO: let's see what the actual type of rcond is so that we can test for
     that specifcially
@@ -1692,11 +1692,11 @@ def test_ptsvx(dtype, fact, de_df_lambda):
         # add 2 so that the matrix will be diagonally dominant
         d = generate_random_dtype_array((n,), dtype=dtype) + 2
     else:
-        # diagonal d should always be real.
+        # Per lapack documentation, diagonal d should always be real.
         # for complex add 4 so it will be dominant
         d = generate_random_dtype_array((n,), DTYPES[1]) + 4
     # diagonal e may be real or complex.
-    e = generate_random_dtype_array(n-1, dtype)
+    e = generate_random_dtype_array((n-1,), dtype)
     # form matrix A from d and e
     A = np.diag(d) + np.diag(e, -1) + np.diag(e, 1)
     # create random solution x
@@ -1706,17 +1706,13 @@ def test_ptsvx(dtype, fact, de_df_lambda):
 
     # use lambda to determine what df, ef are
     # (parametrized to either be null or result of ?pttrf)
-    df, ef, info = de_df_lambda(d, e)
+    df, ef, info = df_de_lambda(d, e)
 
     diag_cpy = [d.copy(), e.copy(), b.copy()]
 
     # solve using routine
-    if fact == "F":
-        x, df, ef, rcond, ferr, berr, info = ptsvx(None, None, b, fact=fact,
-                                                   df=df, ef=ef)
-    else:
-        x, df, ef, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact,
-                                                   df=df, ef=ef)
+    x, df, ef, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact,
+                                               df=df, ef=ef)
     # d, e, and b should be unmodified
     assert_array_equal(d, diag_cpy[0])
     assert_array_equal(e, diag_cpy[1])
@@ -1742,13 +1738,13 @@ def test_ptsvx(dtype, fact, de_df_lambda):
             .format(berr.shape, n))
 
     # test with malformatted array sizes
-    with assert_raises(Exception):
+    with assert_raises(ValueError):
         ptsvx(d[:-1], e, b, fact=fact, df=df, ef=ef)
-    with assert_raises(Exception):
+    with assert_raises(ValueError):
         ptsvx(d, e[:-1], b, fact=fact, df=df, ef=ef)
-    with assert_raises(Exception):
+    with assert_raises(ValueError):
         ptsvx(d, e, b[:-1], fact=fact, df=df, ef=ef)
-
+    '''come back to later if doesnt work to check for nonzero info'''
     # test with non spd matrix
     x, df, ef, rcond, ferr, berr, info = ptsvx(d, e+2, b, fact=fact, df=df,
                                                ef=ef)
@@ -1758,14 +1754,14 @@ def test_ptsvx(dtype, fact, de_df_lambda):
     if fact == "N":
         d[0] = 0
         # obtain new df, ef
-        df, ef, info = de_df_lambda(d, e)
+        df, ef, info = df_de_lambda(d, e)
         # solve using routine
         x, df, ef, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact, df=df,
                                                    ef=ef)
         # test for the singular matrix.
         assert_(d[info - 1] == 0,
-                           "?ptsvx: d[info-1] is {}, not the illegal value"
-                           .format(d[info - 1]))
+                "?ptsvx: d[info-1] is {}, not the illegal value"
+                .format(d[info - 1]))
 
         # non SPD matrix
         d = generate_random_dtype_array(n, dtype)
@@ -1776,16 +1772,15 @@ def test_ptsvx(dtype, fact, de_df_lambda):
                    info, np.linalg.norm(d[info]), np.linalg.norm(e[info])))
     else:
         # assuming that someone is using a singular factorization
-        df, ef = de_df_lambda(d, e)
+        df, ef = df_de_lambda(d, e)
         df[0] = 0
         ef[0] = 0
         x, df, ef, rcond, ferr, berr, info = ptsvx(None, None, b, fact=fact,
                                                    df=df, ef=ef)
         # info should not be zero and should provide index of illegal value
         assert_(d[info - 1] == 0,
-                           "?ptsvx: _d[info-1] is {}, not the illegal value"
-                           .format(d[info - 1]))
-
+                "?ptsvx: _d[info-1] is {}, not the illegal value"
+                .format(d[info - 1]))
 
     # It might be cool to create an example for which the matrix is
     # numerically - but not exactly - singular to see if we can get info==N+1


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Adds tests to: Add wrapper for ?ptsvx #11374

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->

There are several things that we wanted to come back to look at now that there is a wrapper:
* @mdhaber and I noted that in the NAG manual that some berr end ferr values that are zero. I think we wondered why they would be described as zero and if we should test to see if our results are also close to zero.
*   This is something that I didn't implement yet: 
  >     # It might be cool to create an example for which the matrix is
  >     # numerically - but not exactly - singular to see if we can get info==N+1
      
Is this something to revisit? The only case where I get info =n+1 is this case fact = "F", and the user passes in df and ef already factored from pttrf:

```
1792:   # assuming that someone is using a singular factorization
        df, ef, info = df_de_lambda(d, e)
        df[0] = 0
        ef[0] = 0
        df, ef, x, rcond, ferr, berr, info = ptsvx(d, e, b, fact=fact, df=df, ef=ef)
        assert 0 > info >= n
```
info = 6, n = 5. Is this expected?

* lastly, passing in `ptsvx(d, e, b[:-1], fact=fact, df=df, ef=ef)` returns an info of `-9` – is this the right value? Maybe it is counting elements of b when showing which arg is invalid?


Other than that, with a few small modifications the tests pass with a pttrf/s merged branch. If you want to take a look at that one I'll publish it to my repo, it's called lapack_support_ptsvx_pttrfs_merge


(passed when I changed the dimensions for ef to n-1 in the wrapper, in case you didn't see my other comment)