### PR TITLE
ENH/TST: Add wrapper and tests for lapack routine ?gejsv

### DIFF
--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -1630,3 +1630,62 @@ subroutine ilaver(major, minor, patch)
     integer intent(out) :: minor
     integer intent(out) :: patch
 end subroutine ilaver
+
+
+
+subroutine <prefix2>gejsv(joba,jobu,jobv,jobr,jobt,jobp,m,n,a,lda,sva,u,ldu,v,ldv,work,lwork,iwork,info)
+    callstatement(*f2py_func)(joba,jobu,jobv,jobr,jobt,jobp,&m,&n,a,&lda,sva,u,&ldu,v,&ldv,work,&lwork,iwork,&info)
+    callprotoargument char*,char*,char*,char*,char*,char*,int*,int*,<ctype2>*,int*,<ctype2>*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*,<ctype2>*,int*
+
+    character intent(in, optional), check(*joba=='C'||*joba=='E'||*joba=='F'||*joba=='G'||*joba=='A'||*joba=='R') :: joba='C'
+    character intent(in, optional), check(*jobu=='U'||*jobu=='F'||*jobu=='W'||*jobu=='N') :: jobu='U'
+    character intent(in, optional), check(*jobv=='V'||*jobv=='J'||*jobv=='W'||*jobv=='N') :: jobv='V'
+    character intent(in, optional), check(*jobr=='R'||*jobr=='N') :: jobr='R'
+    character intent(in, optional), check(*jobt=='N'||*jobt=='T') :: jobt='N'
+    character intent(in, optional), check(*jobp=='N'||*jobp=='P') :: jobp='N'
+
+    integer intent(hide),depend(a) ::m=shape(a,0)
+    integer intent(hide),depend(a) ::n=shape(a,1)
+    <ftype2> dimension(n,m), intent(in) :: a
+    integer intent(hide), depend(m) :: lda = max(1,m)
+    <ftype2> intent(out), dimension(n) :: sva
+    <ftype2> intent(out), dimension(ldu, n) :: u
+    integer intent(hide), depend(m) :: ldu = max(m, 1)
+    <ftype2> intent(out), dimension(ldv, n) :: v
+    integer intent(hide), depend(n) :: ldv = max(n, 1)
+    <ftype2> intent(out), dimension(lwork) :: work
+    integer intent(in, optional) :: lwork=2*max(2*m+n, max(4*n+n*n,2*n+n*n+6))
+    <ftype2> intent(out), dimension(m+3*n) :: iwork
+    integer intent(out) :: info
+
+end subroutine <prefix2>gejsv
+
+
+subroutine <prefix2c>gejsv(joba,jobu,jobv,jobr,jobt,jobp,m,n,a,lda,sva,u,ldu,v,ldv,cwork,lwork,rwork,lrwork,iwork,info)
+    callstatement(*f2py_func)(joba,jobu,jobv,jobr,jobt,jobp,&m,&n,a,&lda,sva,u,&ldu,v,&ldv,cwork,&lwork,rwork,&lrwork,&iwork,&info)
+    callprotoargument char*,char*,char*,char*,char*,char*,int*,int*,<ctype2c>*,int*,<ctype2>*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2c>*,int*,<ctype2>*,int*,<ctype2>*,int*
+
+    character intent(in, optional), check(*joba=='C'||*joba=='E'||*joba=='F'||*joba=='G'||*joba=='A'||*joba=='R') :: joba='C'
+    character intent(in, optional), check(*jobu=='U'||*jobu=='F'||*jobu=='W'||*jobu=='N') :: jobu='U'
+    character intent(in, optional), check(*jobv=='V'||*jobv=='J'||*jobv=='W'||*jobv=='N') :: jobv='V'
+    character intent(in, optional), check(*jobr=='R'||*jobr=='N') :: jobr='R'
+    character intent(in, optional), check(*jobt=='N'||*jobt=='T') :: jobt='N'
+    character intent(in, optional), check(*jobp=='N'||*jobp=='P') :: jobp='N'
+
+    integer intent(hide),depend(a) :: m=shape(a,0)
+    integer intent(hide),depend(a) :: n=shape(a,1)
+    <ftype2c> dimension(n,m), intent(in) :: a
+    integer intent(hide), depend(m) :: lda = max(1,m)
+    <ftype2> intent(out), dimension(n) :: sva
+    <ftype2c> intent(out), dimension(ldu, n) :: u
+    integer intent(hide), depend(m) :: ldu = max(m, 1)
+    <ftype2c> intent(out), dimension(ldv, n) :: v
+    integer intent(hide),depend(n) :: ldv = n
+    <ftype2c> intent(out), dimension(max(2,lwork)) :: cwork
+    integer intent(in, optional),depend(n,m) :: lwork=2*max(2*m+n, max(4*n+n*n,2*n+n*n+6))
+    <ftype2> intent(hide), dimension(max(7,lwork)) :: rwork
+    integer intent(in, optional),depend(m,n) :: lrwork=2*max(7,max(2*m,n))
+    <ftype2> intent(out):: iwork
+    integer intent(out) :: info
+
+end subroutine <prefix2c>gejsv

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1738,22 +1738,22 @@ def test_gejsv_specific(dtype):
     SIGMA = np.diag(work[1] / work[0] * sva[:n])
     A_rank_k = u @ SIGMA @ v.T
     sva, u, v, work, iwork, info = gejsv(A_rank_k)
-    assert_(k == iwork[0])
-    assert_(k == iwork[1])
+    assert_equal(k, iwork[0])
+    assert_equal(k, iwork[1])
 
     # Invalid job? parameters should result in non zero info
     sva, u, v, work, iwork, info = gejsv(A, joba="L")
-    assert_(info == -3)
+    assert_equal(info, -3)
     sva, u, v, work, iwork, info = gejsv(A, jobu="L")
-    assert_(info == -4)
+    assert_equal(info, -4)
     sva, u, v, work, iwork, info = gejsv(A, jobv="L")
-    assert_(info == -5)
+    assert_equal(info, -5)
     sva, u, v, work, iwork, info = gejsv(A, jobr="L")
-    assert_(info == -6)
+    assert_equal(info, -6)
     sva, u, v, work, iwork, info = gejsv(A, jobt="L")
-    assert_(info == -7)
+    assert_equal(info, -7)
     sva, u, v, work, iwork, info = gejsv(A, jobp="L")
-    assert_(info == -8)
+    assert_equal(info, -8)
 
     # lwork is zero
     sva, u, v, work, iwork, info = gejsv(A, lwork=0)
@@ -1761,15 +1761,15 @@ def test_gejsv_specific(dtype):
     # A is 1D
     A = generate_random_dtype_array((m, 1), dtype)
     sva, u, v, work, iwork, info = gejsv(A)
-    assert_equal(info, 1)
+    assert_equal(info, -1)
     # A is 1 x 1
     A = generate_random_dtype_array((1, 1), dtype)
     sva, u, v, work, iwork, info = gejsv(A)
-    assert_equal(info, 1)
+    assert_equal(info, -1)
     # A is empty
     A = None
     sva, u, v, work, iwork, info = gejsv(A)
-    assert_equal(info, 1)
+    assert_equal(info, -1)
 
 
 @pytest.mark.parametrize("A,sva_expect,u_expect,v_expect",

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1731,6 +1731,16 @@ def test_gejsv_specific(dtype):
     # correct eigenvalues
     assert_allclose(sva, eig(A), rtol=rtol, atol=atol)
 
+    # check that iwork[0] and iwork[1] are the correct rank
+    sva, u, v, work, iwork, info = gejsv(A)
+    k = 3
+    sva[np.random.permutation(min(m, n))[k:]] = 0
+    SIGMA = np.diag(work[1] / work[0] * sva[:n])
+    A_rank_k = u @ SIGMA @ v.T
+    sva, u, v, work, iwork, info = gejsv(A_rank_k)
+    assert_(k == iwork[0])
+    assert_(k == iwork[1])
+
     # Invalid job? parameters should result in non zero info
     sva, u, v, work, iwork, info = gejsv(A, joba="L")
     assert_(info != 0)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1743,33 +1743,33 @@ def test_gejsv_specific(dtype):
 
     # Invalid job? parameters should result in non zero info
     sva, u, v, work, iwork, info = gejsv(A, joba="L")
-    assert_(info != 0)
+    assert_(info == -3)
     sva, u, v, work, iwork, info = gejsv(A, jobu="L")
-    assert_(info != 0)
+    assert_(info == -4)
     sva, u, v, work, iwork, info = gejsv(A, jobv="L")
-    assert_(info != 0)
+    assert_(info == -5)
     sva, u, v, work, iwork, info = gejsv(A, jobr="L")
-    assert_(info != 0)
+    assert_(info == -6)
     sva, u, v, work, iwork, info = gejsv(A, jobt="L")
-    assert_(info != 0)
+    assert_(info == -7)
     sva, u, v, work, iwork, info = gejsv(A, jobp="L")
-    assert_(info != 0)
+    assert_(info == -8)
 
     # lwork is zero
     sva, u, v, work, iwork, info = gejsv(A, lwork=0)
-    assert_(info != 0, "?gejsv info = {}".format(info))
+    assert_(info == -2, "?gejsv info = {}, not -1".format(info))
     # A is 1D
     A = generate_random_dtype_array((m, 1), dtype)
     sva, u, v, work, iwork, info = gejsv(A)
-    assert_(info == 1, "?gejsv info = {}".format(info))
+    assert_(info == 1, "?gejsv info = {}, not 1".format(info))
     # A is 1 x 1
     A = generate_random_dtype_array((1, 1), dtype)
     sva, u, v, work, iwork, info = gejsv(A)
-    assert_(info == 1, "?gejsv info = {}".format(info))
+    assert_(info == 1, "?gejsv info = {}, not 1".format(info))
     # A is empty
     A = None
     sva, u, v, work, iwork, info = gejsv(A)
-    assert_(info == 1, "?gejsv info = {}".format(info))
+    assert_(info == 1, "?gejsv info = {}, not 1".format(info))
 
 
 @pytest.mark.parametrize("A,sva_expect,u_expect,v_expect",

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1703,13 +1703,17 @@ def test_gejsv_general(size, dtype, gejsv_lambda):
     assert_equal(info, 0)
 
     SIGMA = np.diag(work[1] / work[0] * sva[:n])
+    sigma = work[1] / work[0] * sva[:n] # not a matrix
 
+
+    assert_allclose(np.sort(sigma), np.sort(eig(A)[0]), rtol=rtol, atol=atol)
+    # ^ this doesn't seem like it would work as sva is real and eig(A) is complex
     assert_allclose(A, u @ SIGMA @ v.T, rtol=rtol, atol=atol)
     assert_allclose(u.T @ u, np.identity(u.shape[1]), rtol=rtol, atol=atol)
     assert_allclose(v @ v.T, np.identity(n), rtol=rtol, atol=atol)
 
-    assert_equal(iwork[0], np.linagl.matrix_rank(A))
-    assert_equal(iwork[1], np.linagl.matrix_rank(A))
+    #assert_equal(iwork[0], np.linagl.matrix_rank(A))
+    #assert_equal(iwork[1], np.linagl.matrix_rank(A))
 
 
 @pytest.mark.parametrize("dtype", DTYPES)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -1700,7 +1700,7 @@ def test_gejsv_general(size, dtype, gejsv_lambda):
     # pass A and gejsv into lambda expression for parametrized job? values
     sva, u, v, work, iwork, info = gejsv_lambda(A, gejsv)
 
-    assert_(info == 0, "?gejsv info = {}, not 0".format(info))
+    assert_equal(info, 0)
 
     SIGMA = np.diag(work[1] / work[0] * sva[:n])
 
@@ -1708,8 +1708,8 @@ def test_gejsv_general(size, dtype, gejsv_lambda):
     assert_allclose(u.T @ u, np.identity(u.shape[1]), rtol=rtol, atol=atol)
     assert_allclose(v @ v.T, np.identity(n), rtol=rtol, atol=atol)
 
-    assert_(iwork[0] == min(m, n))
-    assert_(iwork[1] == min(m, n))
+    assert_equal(iwork[0], np.linagl.matrix_rank(A))
+    assert_equal(iwork[1], np.linagl.matrix_rank(A))
 
 
 @pytest.mark.parametrize("dtype", DTYPES)
@@ -1757,19 +1757,19 @@ def test_gejsv_specific(dtype):
 
     # lwork is zero
     sva, u, v, work, iwork, info = gejsv(A, lwork=0)
-    assert_(info == -2, "?gejsv info = {}, not -1".format(info))
+    assert_equal(info, -2)
     # A is 1D
     A = generate_random_dtype_array((m, 1), dtype)
     sva, u, v, work, iwork, info = gejsv(A)
-    assert_(info == 1, "?gejsv info = {}, not 1".format(info))
+    assert_equal(info, 1)
     # A is 1 x 1
     A = generate_random_dtype_array((1, 1), dtype)
     sva, u, v, work, iwork, info = gejsv(A)
-    assert_(info == 1, "?gejsv info = {}, not 1".format(info))
+    assert_equal(info, 1)
     # A is empty
     A = None
     sva, u, v, work, iwork, info = gejsv(A)
-    assert_(info == 1, "?gejsv info = {}, not 1".format(info))
+    assert_equal(info, 1)
 
 
 @pytest.mark.parametrize("A,sva_expect,u_expect,v_expect",
@@ -1797,11 +1797,11 @@ def test_gejsv_NAG(A, sva_expect, u_expect, v_expect):
     https://www.nag.com/numeric/fl/nagdoc_latest/html/f08/f08khf.html
     '''
     # NAG manual provides accuracy up to 4 decimals
-    rtol = 1e-4
+    atol = 1e-4
     gejsv = get_lapack_funcs('gejsv', dtype=A.dtype)
 
     sva, u, v, work, iwork, info = gejsv(A)
 
-    assert_allclose(sva_expect, sva, rtol=rtol)
-    assert_allclose(u_expect, u, rtol=rtol)
-    assert_allclose(v_expect, v, rtol=rtol)
+    assert_allclose(sva_expect, sva, atol=atol)
+    assert_allclose(u_expect, u, atol=atol)
+    assert_allclose(v_expect, v, atol=atol)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Helps to resolve: Add wrapper for ?gejsv #11354

#### What does this implement/fix?
<!--Please explain your changes.-->
Adds beginning of wrapper for routine. Adds beginning of tests for routine.

#### Additional information
<!--Any additional information you think is important.-->

I started writing the wrapper, and some parts of it seem to work. I was able to get the realtype to pass the nag test. I have not fully explored why the complex type is not working yet, but it gives info = 6 error for complex64 and segfaults for complex128.

@mdhaber One thing I wondered about is that eig(A) ususally gives some eigenvalues that are complex, but the output of sva is supposedly always real, (also I didn't see any eigenvalue talk in the documentation, maybe I'm a little bit confused about how svd relates to that). I'll ask you tomorrow in person for more details

Kai I didn't see a gejsv branch to pull request to so if you create one I can copy this over to there.

Lastly, I just picked a file to put the routine in, it might not supposed to go there.